### PR TITLE
DM-37925: No longer use alpha releases for weeklies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,10 @@ on:
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -20,16 +24,18 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
           cache-dependency-path: "setup.cfg"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade setuptools wheel
 
       # We have two cores so we can speed up the testing with xdist
       - name: Install pytest packages
         run: pip install pytest pytest-flake8 pytest-openfiles pytest-cov "flake8<5"
-
-      - name: Install prereqs for setuptools
-        run: pip install wheel
 
       - name: List installed packages
         shell: bash -l {0}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.4.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -15,11 +15,11 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.10
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8

--- a/doc/lsst_versions/CHANGES.rst
+++ b/doc/lsst_versions/CHANGES.rst
@@ -1,3 +1,14 @@
+lsst-versions 1.4.0 2023-02-08
+==============================
+
+New Features
+------------
+
+- The calculation of the developer version has been modified.
+  Previously alpha releases were constructed from weekly release tags.
+  This approach, 26.0.0a20230500, resulted in confusion in PyPI installs once a formal release was made.
+  To simplify installations with ``pip`` weekly developer release versions are now of the form 25.2023.500 -- the weekly is encoded in the minor and patchlevel parts of the version and these are now releases derived from the release currently being worked (and not alphas towards the next release).
+
 lsst-versions 1.3.0 2022-07-10
 ==============================
 

--- a/python/lsst_versions/_versions.py
+++ b/python/lsst_versions/_versions.py
@@ -196,9 +196,12 @@ def find_lsst_version(repo_dir: str = ".", version_commit: str = "HEAD") -> str:
     else:
         year, week = weekly_name[2:].split(".")
 
-    # Python pre-release versions must can only have a single integer
-    # after the "a".
-    dev_version = f"{relevant_release + 1}.0.0a{int(year):04d}{int(week):02d}{counter:02d}"
+    # Declare the developer version to be an evolution of the current
+    # release but with the year and week in the minor and patchlevel parts.
+    # Alpha versions for weeklies were used initially but once full releases
+    # are made it becomes very difficult for tooling to ever install the
+    # alphas.
+    dev_version = f"{relevant_release}.{year}.{week}{counter:02d}"
 
     # Convert the version to standard form (this can prevent warnings
     # coming from setuptools later on). For example 1.0.0a07 is rewritten

--- a/python/lsst_versions/_versions.py
+++ b/python/lsst_versions/_versions.py
@@ -247,7 +247,7 @@ def _find_version_path(dirname: str = ".") -> Optional[str]:
 
     if tomli is None:
         warnings.warn(  # type: ignore
-            "The tomli package is not installed. " "Unable to extract version file location."
+            "The tomli package is not installed. Unable to extract version file location."
         )
         return None
 

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -68,7 +68,7 @@ class VersionsTestCase(unittest.TestCase):
         self.assertEqual(version, "1.1.0")
         # test for git repo
         version = get_lsst_version(GITDIR)
-        self.assertEqual(version, "4.0.0a20221037")
+        self.assertEqual(version, "3.2022.1037")
         # test for pyproject
         dirname = os.path.join(datadir, "pyproject")
         version = get_lsst_version(dirname)
@@ -77,17 +77,17 @@ class VersionsTestCase(unittest.TestCase):
     def test_versions(self):
         """Determine versions of a test repository."""
         versions = (
-            ("86427e5", "1.0.0a0"),  # No parents
-            ("86b5d01", "1.0.0a1"),
+            ("86427e5", "0.0.0"),  # No parents
+            ("86b5d01", "0.0.1"),
             ("595e858", "1.0"),
-            ("ea28756", "2.0.0a20220400"),
-            ("af0c308", "2.0.0a20220100"),
-            ("w.2022.1", "2.0.0a20220100"),
-            ("da7a09d", "2.0.0a20220401"),
+            ("ea28756", "1.2022.400"),
+            ("af0c308", "1.2022.100"),
+            ("w.2022.1", "1.2022.100"),
+            ("da7a09d", "1.2022.401"),
             ("v2.1.0", "2.1.0"),
-            ("w.2022.05", "2.0.0a20220700"),
+            ("w.2022.05", "1.2022.700"),
             ("v3.0.0", "3.0.0"),
-            ("3082cf0", "4.0.0a20221001"),
+            ("3082cf0", "3.2022.1001"),
             ("fed5a45", "3.0.0rc2"),
         )
 
@@ -121,7 +121,7 @@ class VersionsTestCase(unittest.TestCase):
 
         # Find a version but do not write.
         version = run_lsst_versions(GITDIR, False)
-        self.assertEqual(version, "4.0.0a20221037")
+        self.assertEqual(version, "3.2022.1037")
         self.assertFalse(os.path.exists(version_path))
 
         # Now write the file.
@@ -129,7 +129,7 @@ class VersionsTestCase(unittest.TestCase):
             version = run_lsst_versions(GITDIR, True)
         self.assertEqual(len(cm.output), 3, cm.output)
         self.assertRegex(cm.output[-1], f"Written version file to .*{version_file}$")
-        self.assertEqual(version, "4.0.0a20221037")
+        self.assertEqual(version, "3.2022.1037")
         self.assertTrue(os.path.exists(version_path))
 
     def test_pyproject_finding(self):


### PR DESCRIPTION
Rather than 26.0.0a20230504 use 25.2023.504 -- these are now "real" releases that are being released before v26 is tagged. 26.0.0 will still be released but will no longer be picked up in preference over a weekly.